### PR TITLE
로그인/로그아웃 시 API Response 규격 적용

### DIFF
--- a/src/main/java/com/groom/tennis_match/auth/AdminRole.java
+++ b/src/main/java/com/groom/tennis_match/auth/AdminRole.java
@@ -1,6 +1,8 @@
 package com.groom.tennis_match.auth;
 
-public enum AdminRole {
+import org.springframework.security.core.GrantedAuthority;
+
+public enum AdminRole implements GrantedAuthority {
     ADMIN(4), CHIEF_MANAGER(3), MANAGER(2), STAFF(1);
 
     private final int level;
@@ -11,6 +13,11 @@ public enum AdminRole {
 
     public int getLevel() {
         return level;
+    }
+
+    @Override
+    public String getAuthority() {
+        return this.name();
     }
 
     /**

--- a/src/main/java/com/groom/tennis_match/auth/entity/Admin.java
+++ b/src/main/java/com/groom/tennis_match/auth/entity/Admin.java
@@ -1,5 +1,6 @@
 package com.groom.tennis_match.auth.entity;
 
+import com.groom.tennis_match.auth.AdminRole;
 import com.groom.tennis_match.common.entity.BaseEntity;
 import com.groom.tennis_match.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -54,9 +55,9 @@ public class Admin extends BaseTimeEntity implements UserDetails {
     private String profileImgUrl;
 
     // Todo : enum type refactoring
+    @Enumerated(EnumType.STRING)
     @Column(length = 20)
-    @Builder.Default
-    private String role = "ADMIN";
+    private AdminRole role;
 
     @Column(length = 50)
     private Long createdBy;
@@ -67,7 +68,7 @@ public class Admin extends BaseTimeEntity implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return List.of(this.role);
     }
 
     @Override

--- a/src/main/java/com/groom/tennis_match/auth/handler/AuthAccessDeniedHandler.java
+++ b/src/main/java/com/groom/tennis_match/auth/handler/AuthAccessDeniedHandler.java
@@ -23,7 +23,7 @@ public class AuthAccessDeniedHandler implements AccessDeniedHandler {
           throws IOException {
     ErrorResponse body = ErrorResponse.of("FORBIDDEN", "접근 권한이 없습니다.", request.getRequestURI());
 
-    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding("UTF-8");
 

--- a/src/main/java/com/groom/tennis_match/auth/handler/AuthAccessDeniedHandler.java
+++ b/src/main/java/com/groom/tennis_match/auth/handler/AuthAccessDeniedHandler.java
@@ -21,7 +21,7 @@ public class AuthAccessDeniedHandler implements AccessDeniedHandler {
   @Override
   public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException ex)
           throws IOException {
-    ErrorResponse body = ErrorResponse.of("FORBIDDEN", "접근 권한이 없습니다.", request.getRequestURI());
+    ErrorResponse body = ErrorResponse.of("FORBIDDEN", "접근 권한이 부족합니다.", request.getRequestURI());
 
     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/groom/tennis_match/auth/handler/AuthAccessDeniedHandler.java
+++ b/src/main/java/com/groom/tennis_match/auth/handler/AuthAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.groom.tennis_match.auth.handler;
+
+
+import com.groom.tennis_match.common.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+@Slf4j
+public class AuthAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException ex)
+          throws IOException {
+    ErrorResponse body = ErrorResponse.of("FORBIDDEN", "접근 권한이 없습니다.", request.getRequestURI());
+
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+
+    jsonConverter.write(body, MediaType.APPLICATION_JSON, new ServletServerHttpResponse(response));
+  }
+}

--- a/src/main/java/com/groom/tennis_match/auth/handler/AuthFailureHandler.java
+++ b/src/main/java/com/groom/tennis_match/auth/handler/AuthFailureHandler.java
@@ -1,9 +1,13 @@
 package com.groom.tennis_match.auth.handler;
 
+import com.groom.tennis_match.common.dto.ErrorResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
@@ -13,15 +17,34 @@ import java.io.IOException;
 @Slf4j
 public class AuthFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
-  private RequestCache requestCache = new HttpSessionRequestCache();
+  private final MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
 
   @Override
-  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-    log.info("Exception Type : " + exception.getClass().getName());
-    log.info("Exception Message : " + exception.getMessage());
+  public void onAuthenticationFailure(HttpServletRequest request,
+                                      HttpServletResponse response,
+                                      AuthenticationException exception)
+          throws IOException, ServletException {
 
-    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); //401 인증 실패
-    response.getWriter().write("fail");
-    log.info("로그인 실패");
+    log.info("Exception Type : {}", exception.getClass().getName());
+    log.info("Exception Message : {}", exception.getMessage());
+
+    // ErrorResponse 생성
+    // TODO : refactor message to i18n resources
+    ErrorResponse errorResponse = ErrorResponse.of(
+            "AUTH_FAILURE",
+            exception.getMessage(),
+            request.getRequestURI()
+    );
+
+    // HTTP 상태코드 설정
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+
+    // JSON 변환 후 응답
+    new MappingJackson2HttpMessageConverter()
+            .write(errorResponse, MediaType.APPLICATION_JSON, new ServletServerHttpResponse(response));
+
+    log.info("Login Failed");
   }
 }

--- a/src/main/java/com/groom/tennis_match/auth/handler/AuthLogoutSuccessHandler.java
+++ b/src/main/java/com/groom/tennis_match/auth/handler/AuthLogoutSuccessHandler.java
@@ -1,33 +1,49 @@
 package com.groom.tennis_match.auth.handler;
 
+import com.groom.tennis_match.common.dto.ApiResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 public class AuthLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
+
+  private final MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
+
   @Override
-  public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+  public void onLogoutSuccess(HttpServletRequest request,
+                              HttpServletResponse response,
+                              Authentication authentication) throws IOException, ServletException {
 
     String username = "Anonymous";
-
-    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-    log.info(authentication.getPrincipal().toString());
-
     if (authentication != null && authentication.getPrincipal() instanceof UserDetails u) {
       username = u.getUsername();
     }
 
-    log.info("로그아웃 성공. 세션 삭제. username={}", username);
+    // 응답 데이터
+    // TODO : refactor message to i18n resources
+    Map<String, Object> data = new HashMap<>();
+    data.put("username", username);
+    ApiResponse<Map<String, Object>> body = ApiResponse.success(data, "로그아웃 성공");
 
-    response.setStatus(200);
-//    response.setContentType("application/json;charset=UTF-8");
-    response.getWriter().write("logout success");
+    // 응답 설정
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+
+    // JSON으로 변환하여 응답
+    jsonConverter.write(body, MediaType.APPLICATION_JSON, new ServletServerHttpResponse(response));
+    log.info("logout successful for user. username={}", username);
   }
 }

--- a/src/main/java/com/groom/tennis_match/auth/handler/AuthSuccessHandler.java
+++ b/src/main/java/com/groom/tennis_match/auth/handler/AuthSuccessHandler.java
@@ -1,67 +1,62 @@
 package com.groom.tennis_match.auth.handler;
 
+import com.groom.tennis_match.common.dto.ApiResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
-import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
-import org.springframework.security.web.savedrequest.RequestCache;
-import org.springframework.security.web.savedrequest.SavedRequest;
-
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  private RequestCache requestCache = new HttpSessionRequestCache();
-
+  private final MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
 
   @Override
-  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-//    SavedRequest savedRequest = requestCache.getRequest(request, response);
-//
-//    if (savedRequest != null) {
-//      requestCache.removeRequest(request, response);
-//      clearAuthenticationAttributes(request);
-//    }
-//
-//    String accept = request.getHeader("accept");
-//
-//    PrincipalDetails principalDetails = null;
-//    if (SecurityContextHolder.getContext().getAuthentication() != null) {
-//      Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-//      if (principal != null && principal instanceof UserDetails) {
-//        principalDetails = (PrincipalDetails) principal;
-//      }
-//    }
-//
-//    // 로그인 시, JSON 으로 반환
-//    MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
-//    MediaType jsonMimeType = MediaType.APPLICATION_JSON;
-//
-//    String message = "로그인 성공";
-//    JsonDto jsonDto = JsonDto.success(principalDetails, message);
-//    if (jsonConverter.canWrite(jsonDto.getClass(), jsonMimeType)) {
-//      jsonConverter.write(jsonDto, jsonMimeType, new ServletServerHttpResponse(response));
-//    }
+  public void onAuthenticationSuccess(HttpServletRequest request,
+                                      HttpServletResponse response,
+                                      Authentication authentication) throws IOException, ServletException {
+
+    // Get user details from the authentication object
     UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-    log.info( "로그인 성공. 세션 발급. username: {}" ,userDetails.getUsername());
 
+    // Prepare data for the JSON response
+    List<String> authorities = authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.toList());
 
-    response.getWriter().write("success");
-  }
+    String sessionId = request.getSession().getId();
 
-  public void setRequestCache(RequestCache requestCache) {
-    this.requestCache = requestCache;
+    Map<String, Object> data = new HashMap<>();
+    data.put("username", userDetails.getUsername());
+    data.put("authorities", authorities);
+    data.put("sessionId", sessionId);
+
+    // Create the success response body
+    // TODO : refactor message to i18n resources
+    ApiResponse<Map<String, Object>> body = ApiResponse.success(data, "로그인 성공");
+
+    // Write the JSON response to the HttpServletResponse
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+
+    jsonConverter.write(body, MediaType.APPLICATION_JSON, new ServletServerHttpResponse(response));
+
+    log.info("Authentication successful for user: {}. Session ID: {}", userDetails.getUsername(), sessionId);
+
+    // Clear authentication attributes to prevent redirect issues
+    clearAuthenticationAttributes(request);
   }
 }

--- a/src/main/java/com/groom/tennis_match/auth/handler/JsonAuthenticationEntryPoint.java
+++ b/src/main/java/com/groom/tennis_match/auth/handler/JsonAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package com.groom.tennis_match.auth.handler;
+
+import com.groom.tennis_match.common.dto.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class JsonAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    ErrorResponse body = ErrorResponse.of("UNAUTHORIZED", "미인증 시 접근할 수 없습니다.", request.getRequestURI());
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    jsonConverter.write(body, MediaType.APPLICATION_JSON, new ServletServerHttpResponse(response));
+  }
+}

--- a/src/main/java/com/groom/tennis_match/auth/service/AdminAuthService.java
+++ b/src/main/java/com/groom/tennis_match/auth/service/AdminAuthService.java
@@ -58,7 +58,7 @@ public class AdminAuthService {
                 .password(encodedPassword)
                 .email(createDTO.getEmail())
                 .name(createDTO.getName())
-                .role(createDTO.getRole().name())
+                .role(createDTO.getRole())
                 .phone(createDTO.getPhone())
                 .build();
 
@@ -145,7 +145,7 @@ public class AdminAuthService {
                 .username(username)
                 .password(passwordEncoder.encode(rawPassword))
                 .name(name)
-                .role(AdminRole.ADMIN.name())
+                .role(AdminRole.ADMIN)
                 .email(email)
                 .phone(phone)
                 .isActive(true)

--- a/src/main/java/com/groom/tennis_match/auth/util/SecurityContextUtil.java
+++ b/src/main/java/com/groom/tennis_match/auth/util/SecurityContextUtil.java
@@ -41,7 +41,7 @@ public class SecurityContextUtil {
      */
     public AdminRole getCurrentUserRole() {
         Admin currentAdmin = getCurrentAdmin();
-        return AdminRole.valueOf(currentAdmin.getRole());
+        return AdminRole.valueOf(currentAdmin.getRole().name());
     }
 
     /**

--- a/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
+++ b/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
@@ -107,7 +107,7 @@ public class SecurityConfig {
 //                        )
                 )
 
-                // 접근 권한 부족 시 해당 핸들러 이용
+                // 접근 권한 부족 시 해당 핸들러 동작
                 .exceptionHandling(ex -> ex
                         .accessDeniedHandler(accessDeniedHandler()) // unauthorized 반환
                 )
@@ -132,7 +132,7 @@ public class SecurityConfig {
 //                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/api/admin/**").permitAll()
-                        .requestMatchers("/**").permitAll()
+//                        .requestMatchers("/**").permitAll()
 //                        .requestMatchers("/actuator/health").permitAll()
                         // 관리자 API는 인증 필요 (권한까지 묶고 싶으면 .hasRole("ADMIN") 등으로)
 //                        .requestMatchers("/api/admin/**").authenticated()

--- a/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
+++ b/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
@@ -1,11 +1,7 @@
-
 package com.groom.tennis_match.config;
 
 import com.groom.tennis_match.auth.filter.JsonUsernamePasswordAuthFilter;
-import com.groom.tennis_match.auth.handler.AuthAccessDeniedHandler;
-import com.groom.tennis_match.auth.handler.AuthFailureHandler;
-import com.groom.tennis_match.auth.handler.AuthLogoutSuccessHandler;
-import com.groom.tennis_match.auth.handler.AuthSuccessHandler;
+import com.groom.tennis_match.auth.handler.*;
 import com.groom.tennis_match.auth.service.AdminDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +15,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -66,6 +63,9 @@ public class SecurityConfig {
     @Bean
     public AccessDeniedHandler accessDeniedHandler() { return new AuthAccessDeniedHandler(); }
 
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() { return new JsonAuthenticationEntryPoint(); }
+
     // Custom JSON login filter as a bean (AuthenticationManager 주입)
     @Bean
     public JsonUsernamePasswordAuthFilter jsonUsernamePasswordAuthFilter(
@@ -109,7 +109,8 @@ public class SecurityConfig {
 
                 // 접근 권한 부족 시 해당 핸들러 동작
                 .exceptionHandling(ex -> ex
-                        .accessDeniedHandler(accessDeniedHandler()) // unauthorized 반환
+                        .authenticationEntryPoint(authenticationEntryPoint()) // unauthorized 반환
+                        .accessDeniedHandler(accessDeniedHandler()) // 권한 부족, forbidden 반환
                 )
 
                 // H2 콘솔 프레임 허용(로컬 개발용)

--- a/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
+++ b/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
@@ -2,6 +2,7 @@
 package com.groom.tennis_match.config;
 
 import com.groom.tennis_match.auth.filter.JsonUsernamePasswordAuthFilter;
+import com.groom.tennis_match.auth.handler.AuthAccessDeniedHandler;
 import com.groom.tennis_match.auth.handler.AuthFailureHandler;
 import com.groom.tennis_match.auth.handler.AuthLogoutSuccessHandler;
 import com.groom.tennis_match.auth.handler.AuthSuccessHandler;
@@ -19,6 +20,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
@@ -61,6 +63,9 @@ public class SecurityConfig {
         return new AuthLogoutSuccessHandler();
     }
 
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler() { return new AuthAccessDeniedHandler(); }
+
     // Custom JSON login filter as a bean (AuthenticationManager 주입)
     @Bean
     public JsonUsernamePasswordAuthFilter jsonUsernamePasswordAuthFilter(
@@ -90,7 +95,7 @@ public class SecurityConfig {
 
         http
                 .securityContext(sc -> sc.requireExplicitSave(false))   // 세션 발급
-                // 세션 기반: 필요 시 생성
+                // 세션 기반
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
 
                 // CSRF: 기본 활성화, 특정 경로만 예외 (H2, JSON 로그인)
@@ -100,6 +105,11 @@ public class SecurityConfig {
 //                                new AntPathRequestMatcher("/h2-console/**"),
 //                                new AntPathRequestMatcher("/api/admin/**")
 //                        )
+                )
+
+                // 접근 권한 부족 시 해당 핸들러 이용
+                .exceptionHandling(ex -> ex
+                        .accessDeniedHandler(accessDeniedHandler()) // unauthorized 반환
                 )
 
                 // H2 콘솔 프레임 허용(로컬 개발용)


### PR DESCRIPTION
## 📌 개요
- 로그인/로그아웃 시 API Response 규격 적용
- 권한 부족 시 부적절한 에러 코드 반환 문제 해결

## 🚀 관련 이슈
- #5
- #8 

## ✅ 변경 사항
- API Resonse 및 Error Response 규격 적용
- 인증 시 Authorities 적용
- 로그인되지 않은 사용자에게 401 에러 출력
- 로그인 및 권한 부족 사용자에게 403 에러 출력