### PR TITLE
Feat/auth 마이 페이지 수정 기능 Username 수정가능하도록 수정

### DIFF
--- a/src/main/java/com/groom/tennis_match/auth/entity/Admin.java
+++ b/src/main/java/com/groom/tennis_match/auth/entity/Admin.java
@@ -72,6 +72,7 @@ public class Admin extends BaseTimeEntity implements UserDetails {
     public void applyProfileUpdate(AdminProfileUpdateRequestDTO dto,
                                    PasswordEncoder passwordEncoder) {
         if (dto.getName() != null) this.name = dto.getName();
+        if (dto.getUsername() != null) this.username = dto.getUsername();
         if (dto.getPhone() != null) this.phone = dto.getPhone();
         if (dto.getEmail() != null) this.email = dto.getEmail();
         if (dto.getProfileImageUrl() != null) this.profileImgUrl = dto.getProfileImageUrl();

--- a/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
+++ b/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.groom.tennis_match.auth.handler.*;
 import com.groom.tennis_match.auth.service.AdminDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -20,12 +21,18 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.List;
 
 @Slf4j
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    @Value("${front.url}")
+    private String frontUrl;  // application.yml의 front.url 주입
 
     private final AdminDetailsService userDetailsService;
 
@@ -94,6 +101,14 @@ public class SecurityConfig {
     ) throws Exception {
 
         http
+                .cors(cors -> cors.configurationSource(request -> {
+                    var config = new CorsConfiguration();
+                    config.setAllowedOrigins(List.of(frontUrl));
+                    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                    config.setAllowedHeaders(List.of("*"));
+                    config.setAllowCredentials(true);
+                    return config;
+                }))
                 .securityContext(sc -> sc.requireExplicitSave(false))   // 세션 발급
                 // 세션 기반
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))

--- a/src/main/java/com/groom/tennis_match/domain/mypage/AdminMyPageController.java
+++ b/src/main/java/com/groom/tennis_match/domain/mypage/AdminMyPageController.java
@@ -29,7 +29,7 @@ public class AdminMyPageController {
   public ApiResponse<AdminProfileDTO> updateAdminProfile(
           @AuthenticationPrincipal Admin admin,
           @RequestBody AdminProfileUpdateRequestDTO requestDTO) {
-    adminMyPageService.updateAdminProfile(requestDTO, admin.getUsername());
+    adminMyPageService.updateAdminProfile(requestDTO, admin.getAdminId());
 
     return ApiResponse.success(SuccessCode.USER_UPDATE_SUCCESS);
   }

--- a/src/main/java/com/groom/tennis_match/domain/mypage/AdminMyPageController.java
+++ b/src/main/java/com/groom/tennis_match/domain/mypage/AdminMyPageController.java
@@ -11,13 +11,13 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
-@RequestMapping("/api")
+@RequestMapping("/api/admin/mypage")
 @RestController
 @RequiredArgsConstructor
 public class AdminMyPageController {
   private final AdminMyPageService adminMyPageService;
 
-  @GetMapping("/admin/mypage")
+  @GetMapping
   public ApiResponse<AdminProfileDTO> getAdminProfile(@AuthenticationPrincipal Admin admin) {
     return ApiResponse.success(
             adminMyPageService.getAdminProfile(admin.getUsername()),
@@ -25,7 +25,7 @@ public class AdminMyPageController {
 
   }
 
-  @PutMapping("/admin/mypage")
+  @PutMapping
   public ApiResponse<AdminProfileDTO> updateAdminProfile(
           @AuthenticationPrincipal Admin admin,
           @RequestBody AdminProfileUpdateRequestDTO requestDTO) {

--- a/src/main/java/com/groom/tennis_match/domain/mypage/AdminMyPageService.java
+++ b/src/main/java/com/groom/tennis_match/domain/mypage/AdminMyPageService.java
@@ -38,23 +38,24 @@ public class AdminMyPageService {
 
   /**
    * 사용자 정보 수정 메서드입니다.
-   * 사용자 아이디는 수정할 수 없으며, 당사자가 수정해야 합니다.
+   * 당사자가 수정해야 합니다.
+   * AuthenticationPrincipal을 통해 adminId를 가져오므로 동일 username을 검증하지 않아도 됩니다.
    * @param requestDTO - 수정할 사용자의 정보입니다.
-   * @param requestUsername - 현재 사용자 정보 수정을 위해 접근한 사용자입니다.
-   * @return
+   * @param requestUserId - 현재 사용자 정보 수정을 위해 접근한 사용자입니다.
+   * @return AdminProfileDTO - 수정이 적용된 프로필을 반환합니다.
    */
   @Transactional
-  public AdminProfileDTO updateAdminProfile(AdminProfileUpdateRequestDTO requestDTO, String requestUsername) {
+  public AdminProfileDTO updateAdminProfile(AdminProfileUpdateRequestDTO requestDTO, Long requestUserId) {
     String username = requestDTO.getUsername();
-    Admin admin = adminRepository.findByUsername(username)
+    Admin admin = adminRepository.findById(requestUserId)
             .orElseThrow(() -> {
-              log.warn("AdminDetailsService - 사용자 없음: username={}", username);
-              return new UsernameNotFoundException("User not found: " + username);
+              log.info("AdminDetailsService - 사용자 없음: UserId={}", requestUserId);
+              return new UsernameNotFoundException("User not found: " + requestUserId);
             });
     admin.applyProfileUpdate(requestDTO, passwordEncoder);
     adminRepository.save(admin);
 
-    return getAdminProfile(requestUsername);
+    return getAdminProfile(username);
 
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,7 @@ logging:
   level:
     org:
       mybatis: debug
+
+## front
+front:
+  url: http://localhost:3000


### PR DESCRIPTION
## 📌 개요
- Username 랜덤 생성으로 인해 로그인하기 힘든 문제 존재, username 또한 수정 가능하도록 수정

## 🚀 관련 이슈
- 

## ✅ 변경 사항
- 프론트 연결을 위한 cors config 및 properties 추가
- handler method 중복 제거
- 마이 페이지에서 username 수정 가능하도록 수정

## 📝 상세 내용
- 세션 정보를 통해 userId를 가져와 사용자를 인식하도록 변경
- username 및 password 등 추가적인 검증 필요