### PR TITLE
valid: 정책 제한 추가

### DIFF
--- a/src/main/java/com/groom/tennis_match/auth/entity/Admin.java
+++ b/src/main/java/com/groom/tennis_match/auth/entity/Admin.java
@@ -52,6 +52,7 @@ public class Admin extends BaseTimeEntity implements UserDetails {
     private short passwordMiss = 0;
 
     @Column(nullable = false)
+    @Setter
     @Builder.Default
     private boolean isLock = false;
 
@@ -83,7 +84,9 @@ public class Admin extends BaseTimeEntity implements UserDetails {
         }
     }
 
-
+    public void increasePasswordMiss() {
+        this.passwordMiss++;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/groom/tennis_match/auth/entity/Admin.java
+++ b/src/main/java/com/groom/tennis_match/auth/entity/Admin.java
@@ -100,6 +100,7 @@ public class Admin extends BaseTimeEntity implements UserDetails {
         return this.username;
     }
 
+    // 계정 유효 기간 만료
     @Override
     public boolean isAccountNonExpired() {
         return UserDetails.super.isAccountNonExpired();
@@ -107,9 +108,10 @@ public class Admin extends BaseTimeEntity implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
-        return UserDetails.super.isAccountNonLocked();
+        return this.isLock();
     }
 
+    // 비밀번호 만료
     @Override
     public boolean isCredentialsNonExpired() {
         return UserDetails.super.isCredentialsNonExpired();
@@ -117,6 +119,6 @@ public class Admin extends BaseTimeEntity implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return UserDetails.super.isEnabled();
+        return this.isActive();
     }
 }

--- a/src/main/java/com/groom/tennis_match/auth/filter/JsonUsernamePasswordAuthFilter.java
+++ b/src/main/java/com/groom/tennis_match/auth/filter/JsonUsernamePasswordAuthFilter.java
@@ -1,7 +1,12 @@
 package com.groom.tennis_match.auth.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groom.tennis_match.auth.entity.Admin;
+import com.groom.tennis_match.auth.service.AdminDetailsService;
+import com.groom.tennis_match.common.constant.ErrorCode;
+import com.groom.tennis_match.common.exception.BusinessException;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -17,9 +22,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.stream.Collectors;
 
+@RequiredArgsConstructor
 @Slf4j
 public class JsonUsernamePasswordAuthFilter extends UsernamePasswordAuthenticationFilter {
   private final ObjectMapper objectMapper = new ObjectMapper();
+  private final AdminDetailsService adminDetailsService;
 
   @Override
   public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
@@ -60,6 +67,20 @@ public class JsonUsernamePasswordAuthFilter extends UsernamePasswordAuthenticati
       log.warn("ID 혹은 PW를 입력하지 않았습니다.");
       throw new AuthenticationServiceException("ID 혹은 PW를 입력하지 않았습니다.");
     }
+
+    // isLock, isActive 검증
+    Admin admin = adminDetailsService.loadUserByUsername(userId);
+
+    if(admin.isLock()) {
+      log.debug("user locked");
+      throw new BusinessException(ErrorCode.ACCOUNT_LOCKED);
+    }
+
+    if(!admin.isActive()) {
+      log.debug("deleted user");
+      throw new BusinessException(ErrorCode.ACCOUNT_DISABLED);
+    }
+
 
     authenticationToken = new UsernamePasswordAuthenticationToken(userId, userPassword);
     this.setDetails(request, authenticationToken);

--- a/src/main/java/com/groom/tennis_match/auth/filter/JsonUsernamePasswordAuthFilter.java
+++ b/src/main/java/com/groom/tennis_match/auth/filter/JsonUsernamePasswordAuthFilter.java
@@ -70,7 +70,21 @@ public class JsonUsernamePasswordAuthFilter extends UsernamePasswordAuthenticati
     this.setDetails(request, authenticationToken);
 
 
-    return this.getAuthenticationManager().authenticate(authenticationToken);
+    try {
+      return this.getAuthenticationManager().authenticate(authenticationToken);
+    } catch (BusinessException e) {
+      log.info(e.getMessage());
+      // AuthenticationFailureHandler를 직접 호출
+      try {
+        unsuccessfulAuthentication(request, response, new AuthenticationServiceException(e.getMessage(), e));
+      } catch (IOException ex) {
+        throw new RuntimeException(ex);
+      } catch (ServletException ex) {
+        throw new RuntimeException(ex);
+      }
+      return null;
+    }
+
 
   }
 

--- a/src/main/java/com/groom/tennis_match/auth/filter/JsonUsernamePasswordAuthFilter.java
+++ b/src/main/java/com/groom/tennis_match/auth/filter/JsonUsernamePasswordAuthFilter.java
@@ -1,12 +1,9 @@
 package com.groom.tennis_match.auth.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.groom.tennis_match.auth.entity.Admin;
-import com.groom.tennis_match.auth.service.AdminDetailsService;
-import com.groom.tennis_match.common.constant.ErrorCode;
 import com.groom.tennis_match.common.exception.BusinessException;
+import jakarta.servlet.ServletException;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -20,13 +17,12 @@ import org.springframework.util.MimeTypeUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
 @Slf4j
 public class JsonUsernamePasswordAuthFilter extends UsernamePasswordAuthenticationFilter {
   private final ObjectMapper objectMapper = new ObjectMapper();
-  private final AdminDetailsService adminDetailsService;
 
   @Override
   public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
@@ -63,27 +59,17 @@ public class JsonUsernamePasswordAuthFilter extends UsernamePasswordAuthenticati
       throw new AuthenticationServiceException("Authentication Method Not Supported : " + request.getMethod());
     }
 
-    if(userId.equals("") || userPassword.equals("")){
+    // id 혹은 password가 null일 시 null pointer exception 생성 가능. 검증 추가
+    // todo: issue - AdminLoginDTO의 @NotBlank가 사용되지 않는다.
+    if (userId == null || userId.isBlank() || userPassword == null || userPassword.isBlank()) {
       log.warn("ID 혹은 PW를 입력하지 않았습니다.");
       throw new AuthenticationServiceException("ID 혹은 PW를 입력하지 않았습니다.");
     }
 
-    // isLock, isActive 검증
-    Admin admin = adminDetailsService.loadUserByUsername(userId);
-
-    if(admin.isLock()) {
-      log.debug("user locked");
-      throw new BusinessException(ErrorCode.ACCOUNT_LOCKED);
-    }
-
-    if(!admin.isActive()) {
-      log.debug("deleted user");
-      throw new BusinessException(ErrorCode.ACCOUNT_DISABLED);
-    }
-
-
     authenticationToken = new UsernamePasswordAuthenticationToken(userId, userPassword);
     this.setDetails(request, authenticationToken);
+
+
     return this.getAuthenticationManager().authenticate(authenticationToken);
 
   }

--- a/src/main/java/com/groom/tennis_match/auth/provider/CustomAuthenticationProvider.java
+++ b/src/main/java/com/groom/tennis_match/auth/provider/CustomAuthenticationProvider.java
@@ -1,0 +1,53 @@
+package com.groom.tennis_match.auth.provider;
+
+import com.groom.tennis_match.auth.entity.Admin;
+import com.groom.tennis_match.auth.service.AdminDetailsService;
+import com.groom.tennis_match.common.constant.ErrorCode;
+import com.groom.tennis_match.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+  private final AdminDetailsService adminDetailsService;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+    log.debug("principal : {}", authentication.getPrincipal());
+
+    String username=(String) authentication.getPrincipal();
+    String password=(String) authentication.getCredentials();
+
+    Admin user = adminDetailsService.loadUserByUsername(username);
+    if(!passwordEncoder.matches(password, user.getPassword())) {
+      throw new BusinessException(ErrorCode.LOGIN_FAILED);
+    }
+
+    if(!user.isActive()) {
+      throw new BusinessException(ErrorCode.ACCOUNT_DISABLED);
+    }
+
+    if(user.isLock()) {
+      throw new BusinessException(ErrorCode.ACCOUNT_LOCKED);
+    }
+
+    return new UsernamePasswordAuthenticationToken(user,
+            null, // for security
+            user.getAuthorities());
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    // AuthenticationProvider가 특정 유형의 인증 객체를 처리할 수 있는지 여부를 결정
+    return (UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication));
+  }
+
+}

--- a/src/main/java/com/groom/tennis_match/auth/provider/CustomAuthenticationProvider.java
+++ b/src/main/java/com/groom/tennis_match/auth/provider/CustomAuthenticationProvider.java
@@ -1,6 +1,7 @@
 package com.groom.tennis_match.auth.provider;
 
 import com.groom.tennis_match.auth.entity.Admin;
+import com.groom.tennis_match.auth.repository.AdminRepository;
 import com.groom.tennis_match.auth.service.AdminDetailsService;
 import com.groom.tennis_match.common.constant.ErrorCode;
 import com.groom.tennis_match.common.exception.BusinessException;
@@ -17,6 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class CustomAuthenticationProvider implements AuthenticationProvider {
   private final AdminDetailsService adminDetailsService;
   private final PasswordEncoder passwordEncoder;
+  private final AdminRepository adminRepository;
 
   @Override
   public Authentication authenticate(Authentication authentication) throws AuthenticationException {
@@ -28,6 +30,10 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 
     Admin user = adminDetailsService.loadUserByUsername(username);
     if(!passwordEncoder.matches(password, user.getPassword())) {
+      user.increasePasswordMiss();
+      user.setLock(user.getPasswordMiss() >= 5); // 5회 이상 넘길 경우 잠금
+
+      adminRepository.save(user);
       throw new BusinessException(ErrorCode.LOGIN_FAILED);
     }
 

--- a/src/main/java/com/groom/tennis_match/auth/service/AdminAuthService.java
+++ b/src/main/java/com/groom/tennis_match/auth/service/AdminAuthService.java
@@ -114,9 +114,7 @@ public class AdminAuthService {
         accountDTO.getPassword();
         String currentUsername = securityContextUtil.getCurrentUsername();
 
-        Admin currentUser = adminRepository.findByUsername(currentUsername).orElseThrow(
-                () -> new BusinessException(ErrorCode.USER_NOT_FOUND)
-        );
+        Admin currentUser = adminRepository.findByUsername(currentUsername).get();
 
         if (passwordEncoder.matches(accountDTO.getPassword(), currentUser.getPassword())) {
             if (accountDTO.getHardDelete()) {

--- a/src/main/java/com/groom/tennis_match/auth/service/AdminAuthService.java
+++ b/src/main/java/com/groom/tennis_match/auth/service/AdminAuthService.java
@@ -114,7 +114,9 @@ public class AdminAuthService {
         accountDTO.getPassword();
         String currentUsername = securityContextUtil.getCurrentUsername();
 
-        Admin currentUser = adminRepository.findByUsername(currentUsername).get();
+        Admin currentUser = adminRepository.findByUsername(currentUsername).orElseThrow(
+                () -> new BusinessException(ErrorCode.USER_NOT_FOUND)
+        );
 
         if (passwordEncoder.matches(accountDTO.getPassword(), currentUser.getPassword())) {
             if (accountDTO.getHardDelete()) {

--- a/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
+++ b/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
@@ -2,17 +2,20 @@ package com.groom.tennis_match.config;
 
 import com.groom.tennis_match.auth.filter.JsonUsernamePasswordAuthFilter;
 import com.groom.tennis_match.auth.handler.*;
+import com.groom.tennis_match.auth.provider.CustomAuthenticationProvider;
 import com.groom.tennis_match.auth.service.AdminDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -35,14 +38,22 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    // Dao provider
+//    // Dao provider
+//    @Bean
+//    public DaoAuthenticationProvider daoAuthenticationProvider(PasswordEncoder encoder) {
+//        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+//        provider.setUserDetailsService(userDetailsService);
+//        provider.setPasswordEncoder(encoder);
+//        return provider;
+//    }
+
+    // custom provider
     @Bean
-    public DaoAuthenticationProvider daoAuthenticationProvider(PasswordEncoder encoder) {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setUserDetailsService(userDetailsService);
-        provider.setPasswordEncoder(encoder);
+    public AuthenticationProvider authenticationProvider(PasswordEncoder encoder) {
+        CustomAuthenticationProvider provider = new CustomAuthenticationProvider(userDetailsService, encoder);
         return provider;
     }
+
 
     // Success/Failure/Logout handlers
     @Bean
@@ -74,7 +85,7 @@ public class SecurityConfig {
             AuthFailureHandler failureHandler
     ) throws Exception {
         AuthenticationManager authManager = authConfig.getAuthenticationManager();
-        JsonUsernamePasswordAuthFilter filter = new JsonUsernamePasswordAuthFilter(userDetailsService);
+        JsonUsernamePasswordAuthFilter filter = new JsonUsernamePasswordAuthFilter();
         filter.setFilterProcessesUrl("/api/admin/auth/login");
         filter.setAuthenticationManager(authManager);
         filter.setUsernameParameter("username");
@@ -88,7 +99,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
-            DaoAuthenticationProvider daoProvider,
+            AuthenticationProvider authenticationProvider,
             AuthLogoutSuccessHandler logoutSuccessHandler,
             JsonUsernamePasswordAuthFilter jsonLoginFilter
     ) throws Exception {
@@ -143,7 +154,7 @@ public class SecurityConfig {
                 )
 
                 // 인증 Provider 등록
-                .authenticationProvider(daoProvider)
+                .authenticationProvider(authenticationProvider)
 
                 // 커스텀 JSON 로그인 필터를 UsernamePasswordAuthenticationFilter 위치에 삽입
                 .addFilterAt(jsonLoginFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
+++ b/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
             AuthFailureHandler failureHandler
     ) throws Exception {
         AuthenticationManager authManager = authConfig.getAuthenticationManager();
-        JsonUsernamePasswordAuthFilter filter = new JsonUsernamePasswordAuthFilter();
+        JsonUsernamePasswordAuthFilter filter = new JsonUsernamePasswordAuthFilter(userDetailsService);
         filter.setFilterProcessesUrl("/api/admin/auth/login");
         filter.setAuthenticationManager(authManager);
         filter.setUsernameParameter("username");

--- a/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
+++ b/src/main/java/com/groom/tennis_match/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.groom.tennis_match.config;
 import com.groom.tennis_match.auth.filter.JsonUsernamePasswordAuthFilter;
 import com.groom.tennis_match.auth.handler.*;
 import com.groom.tennis_match.auth.provider.CustomAuthenticationProvider;
+import com.groom.tennis_match.auth.repository.AdminRepository;
 import com.groom.tennis_match.auth.service.AdminDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ import org.springframework.http.HttpMethod;
 public class SecurityConfig {
 
     private final AdminDetailsService userDetailsService;
+    private final AdminRepository adminRepository;
 
     // Password encoder
     @Bean
@@ -50,7 +52,7 @@ public class SecurityConfig {
     // custom provider
     @Bean
     public AuthenticationProvider authenticationProvider(PasswordEncoder encoder) {
-        CustomAuthenticationProvider provider = new CustomAuthenticationProvider(userDetailsService, encoder);
+        CustomAuthenticationProvider provider = new CustomAuthenticationProvider(userDetailsService, encoder, adminRepository);
         return provider;
     }
 


### PR DESCRIPTION
## 📌 개요
- isLock, isActive 필드를 검증하는 로직 추가

## 🚀 관련 이슈
- 

## ✅ 변경 사항
- JsonUsernamePasswordAuthFilter의 생성 시 DetailsService 추가
- AdminAuthService의 중복 코드 제거

## 📝 상세 내용
- JsonUsernamePasswordAuthFilter에서 DetailsService를 이용해 사용자를 조회하여 상태 필드로 로그인 가능 여부 검증
- 조회 과정에서 USER_NOT_FOUND와 같은 Exception 발생
- AdminAuthService의 경우 내부 레이어이기에 로직 상 나오지 않으므로, 중복 코드 제거

## 추가 사항
- 추가적인 중복 코드 확인 및 제거 필요
- isLock의 경우 비밀번호를 일정 횟수 이상 틀릴 시 카운트되는 passwordMiss 필드와 연계되어 작동함. 해당 로직 구현 필요
- Exception에 대한 정확한 메시지 출력하지 않는 이슈 존재